### PR TITLE
Make GitHub detect *.cf and *.cfs as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.cf linguist-language=Forth
+*.cfs linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect your `.cf` and `.cfs` files as Forth.

Thank you!
